### PR TITLE
✨ [FEAT] Actuator 의존성 추가 및 ELK 보안 추가

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 dependencyManagement {

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -118,6 +118,17 @@ app:
   jwt:
     secret: ${JWT_SECRET_KEY}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+
 springdoc:
   enable-native-support: true
   api-docs:

--- a/search-service/src/main/java/com/traveler/search/global/config/ElasticsearchConfig.java
+++ b/search-service/src/main/java/com/traveler/search/global/config/ElasticsearchConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.util.StringUtils;
 
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "com.traveler.search.domain")
@@ -16,6 +17,16 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
 
     @Value("${spring.elasticsearch.uris}")
     private String esUris;
+
+    // ※ 이 클래스가 ElasticsearchConfiguration을 상속해 ClientConfiguration을 직접 만들기 때문에
+    //    Spring Boot의 ES 자동 설정은 물러난다(back off). 즉 application.yml에
+    //    spring.elasticsearch.username/password 를 적어두기만 해서는 인증이 적용되지 않는다.
+    //    반드시 아래처럼 값을 읽어 withBasicAuth()로 넘겨야 한다.
+    @Value("${spring.elasticsearch.username:}")
+    private String esUsername;
+
+    @Value("${spring.elasticsearch.password:}")
+    private String esPassword;
 
     private final ObjectMapper objectMapper;
 
@@ -25,11 +36,18 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
 
     @Override
     public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
+        ClientConfiguration.TerminalClientConfigurationBuilder builder = ClientConfiguration.builder()
                 .connectedTo(esUris)
                 .withConnectTimeout(Duration.ofSeconds(5))
-                .withSocketTimeout(Duration.ofSeconds(10))
-                .build();
+                .withSocketTimeout(Duration.ofSeconds(10));
+
+        // ES에 xpack.security가 켜져 있을 때만 Basic 인증을 붙인다.
+        // 값이 비어 있으면(보안 미적용 환경) 인증 없이 접속한다.
+        if (StringUtils.hasText(esUsername)) {
+            builder = builder.withBasicAuth(esUsername, esPassword);
+        }
+
+        return builder.build();
     }
 
     @Override

--- a/search-service/src/main/resources/application.yml
+++ b/search-service/src/main/resources/application.yml
@@ -10,7 +10,14 @@ spring:
     import: optional:file:search-service/.env[.properties]
 
   elasticsearch:
+    # 값 형식은 "호스트:포트" (스킴 없음). ElasticsearchConfig의
+    # ClientConfiguration.connectedTo() 가 host:port 를 기대한다.
     uris: ${ELASTICSEARCH_URIS}
+    # ES 보안(xpack.security.enabled: true) 계정.
+    # ※ 이 두 줄만으로는 적용되지 않는다 — global/config/ElasticsearchConfig 가
+    #    이 값을 읽어 withBasicAuth() 로 넘긴다. 비어 있으면 인증 없이 접속.
+    username: ${ELASTICSEARCH_USERNAME:}
+    password: ${ELASTICSEARCH_PASSWORD:}
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}

--- a/user-activity-service/src/main/java/com/traveler/useractivity/global/config/ElasticsearchConfig.java
+++ b/user-activity-service/src/main/java/com/traveler/useractivity/global/config/ElasticsearchConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.util.StringUtils;
 
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "com.traveler.useractivity")
@@ -14,12 +15,29 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
     @Value("${spring.elasticsearch.uris}")
     private String esUris;
 
+    // ※ 이 클래스가 ElasticsearchConfiguration을 상속해 ClientConfiguration을 직접 만들기 때문에
+    //    Spring Boot의 ES 자동 설정은 물러난다(back off). 즉 application.yml에
+    //    spring.elasticsearch.username/password 를 적어두기만 해서는 인증이 적용되지 않는다.
+    //    반드시 아래처럼 값을 읽어 withBasicAuth()로 넘겨야 한다.
+    @Value("${spring.elasticsearch.username:}")
+    private String esUsername;
+
+    @Value("${spring.elasticsearch.password:}")
+    private String esPassword;
+
     @Override
     public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
+        ClientConfiguration.TerminalClientConfigurationBuilder builder = ClientConfiguration.builder()
                 .connectedTo(esUris)
                 .withConnectTimeout(Duration.ofSeconds(5))
-                .withSocketTimeout(Duration.ofSeconds(10))
-                .build();
+                .withSocketTimeout(Duration.ofSeconds(10));
+
+        // ES에 xpack.security가 켜져 있을 때만 Basic 인증을 붙인다.
+        // 값이 비어 있으면(보안 미적용 환경) 인증 없이 접속한다.
+        if (StringUtils.hasText(esUsername)) {
+            builder = builder.withBasicAuth(esUsername, esPassword);
+        }
+
+        return builder.build();
     }
 }

--- a/user-activity-service/src/main/resources/application.yml
+++ b/user-activity-service/src/main/resources/application.yml
@@ -10,7 +10,14 @@ spring:
     import: optional:file:user-activity-service/.env[.properties]
 
   elasticsearch:
+    # 값 형식은 "호스트:포트" (스킴 없음). ElasticsearchConfig의
+    # ClientConfiguration.connectedTo() 가 host:port 를 기대한다.
     uris: ${ELASTICSEARCH_URIS}
+    # ES 보안(xpack.security.enabled: true) 계정.
+    # ※ 이 두 줄만으로는 적용되지 않는다 — global/config/ElasticsearchConfig 가
+    #    이 값을 읽어 withBasicAuth() 로 넘긴다. 비어 있으면 인증 없이 접속.
+    username: ${ELASTICSEARCH_USERNAME:}
+    password: ${ELASTICSEARCH_PASSWORD:}
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 💡 관련 이슈
- Close #32 

## 🛠 작업 내용
- api-gateway
  - spring-boot-starter-actuator 의존성 추가
  - /actuator/health/liveness API 활성화
- useractivity-service
  - elasticsearch username, password 추가
  - ElasticsearchConfig 수정
- search-service
  - elasticsearch username, password 추가
  - ElasticsearchConfig 수정